### PR TITLE
Switch to Puppet 4 data types and make 'bits' an integer. 

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,57 +1,82 @@
-# Define: ssh_keygen
-# Parameters:
-# $user
-# $type
-# $bits
-# $home
-# $filename
-# $comment
-# $options
+# ssh_keygen
+#
+# @summary Generate ssh keys for a user resource using ssh_keygen.
+#
+# @example Generate ssh keys for any user using ssh_keygen. The user must exist before using the module
+#  ssh_keygen { 'john': }
+#
+# @example If not using the default `/home/john`
+#  ssh_keygen { 'john':
+#    home => '/var/home'
+#  }
+#
+# @example The key comment can also be overriden with
+#  ssh_keygen { 'john':
+#    comment => 'john key'
+#  }
+
+# @example Generate a dsa key
+#  ssh_keygen { 'john':
+#    type => 'dsa'
+#  }
+#
+# @example specify the bit length
+#  ssh_keygen { 'john':
+#    bits => '4096'
+#  }
+#
+# @example Generate new host key
+#  ssh_keygen { 'root':
+#    filename => '/etc/ssh/ssh_host_rsa_key'
+#  }
+#
+# @param user Username to create key for
+# @param type Type of key to create
+# @param bits Number of bits in key
+# @param home Home directory for user
+# @param filename Key filename
+# @param comment Key comment
+# @param options Additional options to pass on to ssh-keygen
 #
 define ssh_keygen (
-  $user     = undef,
-  $type     = undef,
-  $bits     = undef,
-  $home     = undef,
-  $filename = undef,
-  $comment  = undef,
-  $options  = undef,
+  Optional[String] $user     = undef,
+  Enum['rsa', 'dsa'] $type   = 'rsa',
+  Optional[Integer] $bits    = undef,
+  Optional[String] $home     = undef,
+  Optional[String] $filename = undef,
+  Optional[String] $comment  = undef,
+  Optional[String] $options  = undef,
 ) {
 
   Exec { path => '/bin:/usr/bin' }
 
-  $user_real = $user ? {
+  $_user = $user ? {
     undef   => $name,
     default => $user,
   }
 
-  $type_real = $type ? {
-    undef   => 'rsa',
-    default => $type,
-  }
-
-  $home_real = $home ? {
-    undef   => $user_real ? {
-      'root'  => "/${user_real}",
-      default => "/home/${user_real}",
+  $_home = $home ? {
+    undef   => $_user ? {
+      'root'  => "/${_user}",
+      default => "/home/${_user}",
     },
     default => $home,
   }
 
-  $filename_real = $filename ? {
-    undef   => "${home_real}/.ssh/id_${type_real}",
+  $_filename = $filename ? {
+    undef   => "${_home}/.ssh/id_${type}",
     default => $filename,
   }
 
-  $type_opt = " -t ${type_real}"
+  $type_opt = " -t ${type}"
 
   $bits_opt = $bits ? {
     undef   => undef,
     default => " -b ${bits}"
   }
 
-  $filename_opt = " -f '${filename_real}'"
-  $n_passphrase_opt = " -N ''"
+  $filename_opt = " -f '${_filename}'"
+  $passphrase_opt = " -N ''"
 
   $comment_opt = $comment ? {
     undef   => undef,
@@ -64,9 +89,8 @@ define ssh_keygen (
   }
 
   exec { "ssh_keygen-${name}":
-    command => "ssh-keygen${type_opt}${bits_opt}${filename_opt}${n_passphrase_opt}${comment_opt}${options_opt}",
-    user    => $user_real,
-    creates => $filename_real,
+    command => "ssh-keygen${type_opt}${bits_opt}${filename_opt}${passphrase_opt}${comment_opt}${options_opt}",
+    user    => $_user,
+    creates => $_filename,
   }
-
 }

--- a/spec/defines/init_spec.rb
+++ b/spec/defines/init_spec.rb
@@ -53,7 +53,7 @@ describe 'ssh_keygen' do
   end
 
   context 'passing bits parameter' do
-    let(:params) { { bits: '4096' } }
+    let(:params) { { bits: 4096 } }
 
     it {
       is_expected.to contain_exec('ssh_keygen-john').with(


### PR DESCRIPTION
- Switch to Puppet 4 data types
- Change 'bits' to require an integer
- Switch `foo_real` to `_foo` internally
- Document using puppet-strings.