### PR TITLE
Support more key types

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,7 +40,7 @@
 #
 define ssh_keygen (
   Optional[String] $user     = undef,
-  Enum['rsa', 'dsa'] $type   = 'rsa',
+  Enum['rsa', 'dsa', 'ecdsa', 'ed25519', 'rsa1'] $type   = 'rsa',
   Optional[Integer] $bits    = undef,
   Optional[String] $home     = undef,
   Optional[String] $filename = undef,


### PR DESCRIPTION
Sync possible key types with those suported by ssh-keygen.

For example, compared to rsa, ed25519 is much faster while providing a similar level of security.