### PR TITLE
Ability to overwrite existing keys.

### DIFF
--- a/spec/defines/init_spec.rb
+++ b/spec/defines/init_spec.rb
@@ -122,7 +122,18 @@ describe 'ssh_keygen' do
       expect(subject).to contain_exec('ssh_keygen-john').with(
         command: "ssh-keygen -t rsa -f /home/john/.ssh/id_rsa -N '' -q",
         user: 'john',
-        creates: '/home/john/.ssh/id_rsa'
+        creates: '/home/john/.ssh/id_rsa',
+      )
+    }
+  end
+
+  context 'overwrite existing key' do
+    let(:params) { { force: true } } 
+
+    it {
+      expect(subject).to contain_exec('ssh_keygen-john').with(
+        command: "ssh-keygen -t rsa -f /home/john/.ssh/id_rsa -N '' <<<y",
+        user: 'john',
       )
     }
   end


### PR DESCRIPTION
Added ability to overwrite existing SSH keys.  This is helpful if policy or CIS compliance requires periodic rotation of user's SSH keys. 


#### This Pull Request (PR) fixes the following issues
Fixes #82 
